### PR TITLE
Fix pip package name for Git revision date plugin

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ mkdocs
 mkdocs-material
 mkdocs-jupyter
 mkdocs-gen-files
-git-revision-date-localized
+mkdocs-git-revision-date-localized-plugin
 pymdown-extensions
 pandas


### PR DESCRIPTION
## Summary
- fix `git-revision-date-localized` installation by using the correct package name

## Testing
- `python -m pip install -r requirements.txt`
- `python scripts/generate_docs.py` *(fails: Missing optional dependency 'tabulate')*

------
https://chatgpt.com/codex/tasks/task_e_6883d7783eec832d9fab74c759f95fb8