### PR TITLE
Fix MkDocs extra configuration

### DIFF
--- a/docs/assets/js/extra.js
+++ b/docs/assets/js/extra.js
@@ -1,0 +1,1 @@
+// Custom JS

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,7 +14,7 @@ theme:
     - toc.integrate
 
 extra_css:
-  - assets/css/extra.css
+  - stylesheets/extra.css
 extra_javascript:
   - assets/js/extra.js
 


### PR DESCRIPTION
## Summary
- point `extra_css` at the existing `stylesheets/extra.css`
- create missing `docs/assets/js/extra.js`

## Testing
- `python scripts/generate_docs.py`
- `mkdocs build -q` *(fails: The "mkdocs-gen-files" plugin is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6883ef723900832d96c4635b37f4a303