### PR TITLE
Copy source into docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -206,3 +206,4 @@ marimo/_static/
 marimo/_lsp/
 __marimo__/
 docs/generated/
+docs/src/


### PR DESCRIPTION
## Summary
- copy `src/` into `docs/src/` during doc generation
- skip files ignored by `.gitignore`
- ignore generated source folder in repo

## Testing
- `python scripts/generate_docs.py`

------
https://chatgpt.com/codex/tasks/task_e_6883ef8767e0832dbc8982ab6da5f18e