### PR TITLE
Fix docs nav

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -41,5 +41,4 @@ nav:
   - Home: index.md
   - Getting Started:
       - Overview: getting-started/index.md
-  - API:
-      - Package: api/index.md
+  - Guide: guide.md


### PR DESCRIPTION
## Summary
- clean up nav in `mkdocs.yml`

## Testing
- `python scripts/generate_docs.py`
- `mkdocs build` *(fails: mkdocs-gen-files plugin not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6883ef75cf8c832d999541e6813d5762