### PR TITLE
Automate nav generation

### DIFF
--- a/scripts/generate_docs.py
+++ b/scripts/generate_docs.py
@@ -2,10 +2,12 @@ import os
 import shutil
 from pathlib import Path
 import pandas as pd
+import yaml
 
 SRC_DIR = Path('src')
-GENERATED_DIR = Path('docs/generated')
-ASSETS_PDF_DIR = Path('docs/assets/pdfs')
+DOCS_DIR = Path('docs')
+GENERATED_DIR = DOCS_DIR / 'generated'
+ASSETS_PDF_DIR = DOCS_DIR / 'assets/pdfs'
 
 
 def clean_generated():
@@ -54,7 +56,59 @@ def generate_index(processed_paths):
         f.write('# Generated Documentation Index\n\n')
         for rel in sorted(processed_paths):
             page = rel.with_suffix('.md') if rel.suffix != '.ipynb' else rel
-            f.write(f'- [{page.stem}]({page.as_posix()})\n')
+        f.write(f'- [{page.stem}]({page.as_posix()})\n')
+
+
+def _insert_nav(nav_list, parts, target):
+    """Recursively insert a file path into the nav structure."""
+    title = parts[0].replace('-', ' ').title()
+    if len(parts) == 1:
+        nav_list.append({title: target})
+        return
+
+    # locate or create sublist for this directory
+    for item in nav_list:
+        if isinstance(item, dict) and title in item:
+            sub = item[title]
+            break
+    else:
+        sub = []
+        nav_list.append({title: sub})
+
+    _insert_nav(sub, parts[1:], target)
+
+
+def generate_nav():
+    """Walk DOCS_DIR and build a nav structure."""
+    files = []
+    for path in DOCS_DIR.rglob('*'):
+        if not path.is_file():
+            continue
+        if 'assets' in path.parts or 'stylesheets' in path.parts:
+            continue
+        if path.suffix not in {'.md', '.ipynb'}:
+            continue
+        files.append(path.relative_to(DOCS_DIR))
+
+    nav = []
+    for rel in sorted(files):
+        if rel.as_posix() == 'index.md':
+            nav.insert(0, {'Home': rel.as_posix()})
+        else:
+            _insert_nav(nav, list(rel.parts), rel.as_posix())
+    return nav
+
+
+def merge_nav(nav):
+    nav_text = yaml.dump({'nav': nav}, sort_keys=False)
+    with open('mkdocs.yml', 'r') as f:
+        content = f.read()
+    idx = content.find('nav:')
+    if idx != -1:
+        content = content[:idx]
+    content = content.rstrip() + '\n' + nav_text
+    with open('mkdocs.yml', 'w') as f:
+        f.write(content)
 
 
 def main():
@@ -77,6 +131,8 @@ def main():
             processed.append(rel_path)
     generate_index(processed)
     print('Processed', len(processed), 'files')
+    nav = generate_nav()
+    merge_nav(nav)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- crawl docs/ and src/ recursively in `generate_docs.py`
- build nav from discovered docs
- rewrite `mkdocs.yml` nav during doc build

## Testing
- `python scripts/generate_docs.py`
- `mkdocs build` *(fails: mkdocs-gen-files plugin not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6883ef7f136c832d9b8cd5b7c89cb1c1